### PR TITLE
remove "questionable" and "unsafe" functions from current modules

### DIFF
--- a/src/luerl_emul.erl
+++ b/src/luerl_emul.erl
@@ -40,6 +40,8 @@
 -export([call/2,call/3,emul/2]).
 -export([load_chunk/2,load_chunk/3]).
 
+-export([load_libs/2]).
+
 -export([functioncall/3,methodcall/4,
 	 set_global_key/3,get_global_key/2,
 	 get_table_keys/2,get_table_keys/3,

--- a/src/luerl_lib_basic.erl
+++ b/src/luerl_lib_basic.erl
@@ -34,32 +34,21 @@ install(St) ->
 %% table() -> [{FuncName,Function}].
 %% Caller will convert this list to the correct format.
 
+%% only "safe" functions per http://lua-users.org/wiki/SandBoxes
 table() ->
     [{<<"_VERSION">>,<<"Lua 5.3">>},            %We are optimistic
      {<<"assert">>,#erl_func{code=fun assert/2}},
-     {<<"collectgarbage">>,#erl_func{code=fun collectgarbage/2}},
-     {<<"dofile">>,#erl_func{code=fun dofile/2}},
      {<<"eprint">>,#erl_func{code=fun eprint/2}},
      {<<"error">>,#erl_func{code=fun basic_error/2}},
-     {<<"getmetatable">>,#erl_func{code=fun getmetatable/2}},
      {<<"ipairs">>,#erl_func{code=fun ipairs/2}},
-     {<<"load">>,#erl_func{code=fun load/2}},
-     {<<"loadfile">>,#erl_func{code=fun loadfile/2}},
-     {<<"loadstring">>,#erl_func{code=fun loadstring/2}}, %For Lua 5.1 compatibility
      {<<"next">>,#erl_func{code=fun next/2}},
      {<<"pairs">>,#erl_func{code=fun pairs/2}},
      {<<"pcall">>,#erl_func{code=fun pcall/2}},
      {<<"print">>,#erl_func{code=fun print/2}},
-     {<<"rawequal">>,#erl_func{code=fun rawequal/2}},
-     {<<"rawget">>,#erl_func{code=fun rawget/2}},
-     {<<"rawlen">>,#erl_func{code=fun rawlen/2}},
-     {<<"rawset">>,#erl_func{code=fun rawset/2}},
      {<<"select">>,#erl_func{code=fun select/2}},
-     {<<"setmetatable">>,#erl_func{code=fun setmetatable/2}},
      {<<"tonumber">>,#erl_func{code=fun tonumber/2}},
      {<<"tostring">>,#erl_func{code=fun tostring/2}},
-     {<<"type">>,#erl_func{code=fun type/2}},
-     {<<"unpack">>,#erl_func{code=fun unpack/2}}	%For Lua 5.1 compatibility
+     {<<"type">>,#erl_func{code=fun type/2}}
     ].
 
 assert(As, St) ->

--- a/src/luerl_lib_package.erl
+++ b/src/luerl_lib_package.erl
@@ -31,14 +31,14 @@
 -export([install/1]).
 
 %% Export some functions which can be called from elsewhere.
--export([search_path/5]).
+-export([search_path/5, require/2]).
 
 -import(luerl_lib, [lua_error/2,badarg_error/3]).	%Shorten this
 
 install(St0) ->
-    St1 = luerl_emul:set_global_key(<<"require">>,
-				    #erl_func{code=fun require/2}, St0),
-    {S,St2} = luerl_heap:alloc_table(searchers_table(), St1),
+    %%St1 = luerl_emul:set_global_key(<<"require">>,
+	%%			    #erl_func{code=fun require/2}, St0),
+    {S,St2} = luerl_heap:alloc_table(searchers_table(), St0),
     {L,St3} = luerl_heap:alloc_table(loaded_table(), St2),
     {P,St4} = luerl_heap:alloc_table(preload_table(), St3),
     {T,St5} = luerl_heap:alloc_table(table(S, L, P), St4),

--- a/src/luerl_lib_string.erl
+++ b/src/luerl_lib_string.erl
@@ -47,7 +47,6 @@ metatable(T) ->					%String type metatable
 table() ->					%String table
     [{<<"byte">>,#erl_func{code=fun byte/2}},
      {<<"char">>,#erl_func{code=fun char/2}},
-     {<<"dump">>,#erl_func{code=fun dump/2}},
      {<<"find">>,#erl_func{code=fun find/2}},
      {<<"format">>,#erl_func{code= fun format/2}},
      {<<"gmatch">>,#erl_func{code=fun gmatch/2}},


### PR DESCRIPTION
guided by http://lua-users.org/wiki/SandBoxes
only addressed our active modules (basic, string and table)